### PR TITLE
Решение проблемы использования adapterMode=0

### DIFF
--- a/src/testit_api_client/model/test_result_v2_get_model.py
+++ b/src/testit_api_client/model/test_result_v2_get_model.py
@@ -237,7 +237,8 @@ class TestResultV2GetModel(ModelNormal):
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \
                         self._configuration.discard_unknown_keys and \
-                        self.additional_properties_type is None:
+                        self.additional_properties_type is None or \
+                        var_value is None:
                 # discard variable.
                 continue
             setattr(self, var_name, var_value)


### PR DESCRIPTION
Решение ошибки запуска автотестов с adapterMode=0 из интерфйса "Автотесты", зависит от [этого исправления](https://github.com/testit-tms/adapters-python/pull/27) в testit-adapter-pytest (Необходимо внести его совместно с данным исправлением)
Часть трейса ошибки
- testit_api_client.exceptions.ApiTypeError: Invalid type for variable 'test_point'. Required value type is TestPointShortModel and passed type was NoneType at ['received_data']['test_results'][0]['test_point']

Версия API Client 2.0, Test IT 3.5