### PR TITLE
Перевод outcome в правильный формат

### DIFF
--- a/src/testit_api_client/model/auto_test_results_for_test_run_model.py
+++ b/src/testit_api_client/model/auto_test_results_for_test_run_model.py
@@ -325,7 +325,7 @@ class AutoTestResultsForTestRunModel(ModelNormal):
 
         self.configuration_id = configuration_id
         self.auto_test_external_id = auto_test_external_id
-        self.outcome = outcome
+        self.outcome = outcome.lower().capitalize()
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \


### PR DESCRIPTION
Теперь переменная outcome будет в правильном формате - в нижнем регистре с заглавной буквой