### PR TITLE
Fix duration validation for TestResultUpdateV2Request and ApiV2TestResultsIdPutRequest

### DIFF
--- a/src/testit_api_client/model/api_v2_test_results_id_put_request.py
+++ b/src/testit_api_client/model/api_v2_test_results_id_put_request.py
@@ -75,11 +75,11 @@ class ApiV2TestResultsIdPutRequest(ModelComposed):
 
     validations = {
         ('duration_in_ms',): {
-            'inclusive_maximum': -9223372036854775616,
+            'inclusive_maximum': 9223372036854775807,
             'inclusive_minimum': 0,
         },
         ('duration',): {
-            'inclusive_maximum': -9223372036854775616,
+            'inclusive_maximum': 9223372036854775807,
             'inclusive_minimum': 0,
         },
     }

--- a/src/testit_api_client/model/test_result_update_v2_request.py
+++ b/src/testit_api_client/model/test_result_update_v2_request.py
@@ -73,11 +73,11 @@ class TestResultUpdateV2Request(ModelNormal):
 
     validations = {
         ('duration_in_ms',): {
-            'inclusive_maximum': -9223372036854775616,
+            'inclusive_maximum': 9223372036854775807,
             'inclusive_minimum': 0,
         },
         ('duration',): {
-            'inclusive_maximum': -9223372036854775616,
+            'inclusive_maximum': 9223372036854775807,
             'inclusive_minimum': 0,
         },
     }


### PR DESCRIPTION
This pull request fixes the validation for duration_in_ms and duration in the following files:
• testit_api_client/model/test_result_update_v2_request.py
• testit_api_client/model/api_v2_test_results_id_put_request.py

Problem:
Previously, the inclusive_maximum for these fields was set to a negative number (-9223372036854775616), which caused errors when sending test results with normal durations (e.g., 2150 ms).

Solution:
• Updated inclusive_maximum to 9223372036854775807 (maximum int64 value).
• inclusive_minimum remains 0.
• This allows valid durations to pass validation without errors.

Related issue:
https://github.com/testit-tms/api-client-python/issues/62

Additional notes:
No other changes were made. The PR only updates validation constants.